### PR TITLE
slight change to hudwarp and PIX.

### DIFF
--- a/core.h
+++ b/core.h
@@ -85,6 +85,9 @@
 #define R1DAssert(e) (e)
 #endif
 
+#define Stringify_(S) #S
+#define Stringify(S) Stringify_(S)
+
 extern uint64_t g_PerformanceFrequency;
 
 extern int G_is_dedi;

--- a/hudwarp.h
+++ b/hudwarp.h
@@ -51,16 +51,15 @@ private:
 	UINT m_originalNumViewports = 0;
 	D3D11_VIEWPORT m_pOriginalViewports[D3D11_VIEWPORT_AND_SCISSORRECT_OBJECT_COUNT_PER_PIPELINE]{ 0 };
 
-	XMMATRIX mOrtho{};
 	HudwarpSettings m_hudwarpSettings{};
 
 	unsigned int m_width = 0;
 	unsigned int m_height = 0;
 };
 
-struct ConstantBuffer
+// NOTE(mrsteyk): old GPU stuff, 16 byte alignment is required.
+struct alignas(16) ConstantBuffer
 {
-	XMMATRIX mProjection;
 	float aspectRatio;
 	// Hudwarp settings
 	float xWarp;
@@ -82,7 +81,6 @@ struct Vertex
 constexpr const char* hudwarpShader = R"(
 cbuffer ConstantBuffer : register(b0)
 {
-	matrix projection;
 	float aspectRatio;
 	// Hudwarp settings
 	float xWarp;
@@ -98,30 +96,30 @@ struct PSI
 	float2 texCoord : TEXCOORD;
 };
 
-// VertexShader
-PSI VS( float4 pos : POSITION, float2 texCoord : TEXCOORD )
-{
-	PSI psi;
-	psi.texCoord = texCoord;
-	pos = mul( pos, projection );
-	psi.pos = pos;
-	return psi;
-}
-// PixelShader
-Texture2D<float4> Texture : register(t0);
-sampler Sampler : register(s0);
-
 // Border correction from sub_1800084F0_Hook
 float2 UndoHudTexBorder(float2 texCoord)
 {
 	// IMPORTANT: must match value of HUD_TEX_BORDER_SIZE
-	float hudTexBorderSize = 0.025f;
+	float hudTexBorderSize =)" Stringify(HUD_TEX_BORDER_SIZE) R"(;
 
 	float hudScale = 1.0f + 2.0f * hudTexBorderSize;
 	float hudOffset = 0.5f - (0.5f / hudScale);
 
 	return texCoord / hudScale + hudOffset;
 }
+
+// VertexShader
+PSI VS( float4 pos : POSITION, float2 texCoord : TEXCOORD )
+{
+	PSI psi;
+	//psi.texCoord = texCoord;
+	psi.texCoord = UndoHudTexBorder(texCoord);
+	psi.pos = pos;
+	return psi;
+}
+// PixelShader
+Texture2D<float4> Texture : register(t0);
+sampler Sampler : register(s0);
 
 float2 NormalizeUV(float2 uv)
 {
@@ -169,7 +167,8 @@ float4 PS(PSI psi) : SV_TARGET
 		return float4(0.0f, 0.0f, 0.0f, 0.0f);
 	}
 
-	float2 uv = UndoHudTexBorder(psi.texCoord);
+	//float2 uv = UndoHudTexBorder(psi.texCoord);
+    float2 uv = psi.texCoord;
 	uv -= 0.5f;
 	uv *= 2.0f;
 	uv /= float2(xScale, yScale);

--- a/hudwarp_hooks.cpp
+++ b/hudwarp_hooks.cpp
@@ -195,6 +195,8 @@ void __fastcall CMatSystemSurface__ApplyHudwarpSettings(void* thisptr, HudwarpSe
 	hudwarp_chopsize->m_Value.m_nValue = originalChopsize;
 }
 
+// TODO(mrsteyk): figure out better flags?
+#if BUILD_DEBUG
 static void BeginPixEvent_(const char* name)
 {
 	if (PIX)
@@ -254,8 +256,6 @@ static void SetPixMarker_(const char* name)
 	}
 }
 
-// TODO(mrsteyk): figure out better flags?
-#if BUILD_DEBUG
 void EndPixEvent_Hook(void* queueRenderContext)
 {
 	EndPixEvent_();
@@ -265,6 +265,10 @@ void SetPixMarker_Hook(void* queueRenderContext, uint32_t color, const char* psz
 {
 	SetPixMarker_(pszName);
 }
+#else
+#define BeginPixEvent_(...)
+#define EndPixEvent_(...)
+#define SetPixMarker_(...)
 #endif
 
 void __fastcall BeginPixEvent_Hook(void* queuedRenderContext, unsigned long color, const char* pszName) {

--- a/load.cpp
+++ b/load.cpp
@@ -881,6 +881,7 @@ uintptr_t G_server;
 uintptr_t G_engine;
 uintptr_t G_engine_ds;
 uintptr_t G_client;
+uintptr_t G_matsystem;
 uintptr_t G_localize;
 ILocalize* G_localizeIface;
 
@@ -3048,6 +3049,7 @@ void __stdcall LoaderNotificationCallback(
 		MH_EnableHook(MH_ALL_HOOKS);
 	}
 	else if (string_equal_size(name, name_len, L"materialsystem_dx11.dll")) {
+		G_matsystem = (uintptr_t)notification_data->Loaded.DllBase;
 		SetupHudWarpMatSystemHooks();
 		MH_EnableHook(MH_ALL_HOOKS);
 	}

--- a/load.h
+++ b/load.h
@@ -108,6 +108,7 @@ extern uintptr_t G_server;
 extern uintptr_t G_engine;
 extern uintptr_t G_engine_ds;
 extern uintptr_t G_client;
+extern uintptr_t G_matsystem;
 extern uintptr_t G_localize;
 extern ILocalize* G_localizeIface;
 static bool(__fastcall* o_pCLocalise__AddFile)(void* pVguiLocalize, const char* path, const char* pathId, bool bIncludeFallbackSearchPaths);


### PR DESCRIPTION
 * Changed hudwarp to undo border per vertex, since there's 0 dependency on where you are exactly, unlike Distort.
 * Enable level 3 optimisations when compiling shaders.
 * Stringify(HUD_TEX_BORDER_SIZE)
 * Remove some useless static variables.
 * You can't remove dumb string comparison due to async-ish command recording in main thread and executing in render.
 * Fix naming. IDK why Barnaby thought it was a marker.
 * Change PIX hooks to actual nullsub calls.

This PR slightly changes how hudwarp looks, is it better or is it worse - it's up to you